### PR TITLE
Support multiple consumer attributes per worker

### DIFF
--- a/bin/mammatus-queue
+++ b/bin/mammatus-queue
@@ -13,9 +13,9 @@ use Mammatus\ContainerFactory;
     require_once $_composer_autoload_path;
 })($_composer_autoload_path);
 
-(static function(string $className) {
+(static function(string $hash) {
     /**
      * Create and run that one cron job
      */
-    exit(Boot::boot(App::class, new App\Queue($className))->value);
+    exit(Boot::boot(App::class, new App\Queue($hash))->value);
 })($argv[1]);

--- a/composer.lock
+++ b/composer.lock
@@ -1263,12 +1263,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/MammatusPHP/app.git",
-                "reference": "474b586055a41313eaee3efa2d7a34522fde5626"
+                "reference": "e014bf55d88d88c6a02008431f5130cb75fdef34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MammatusPHP/app/zipball/474b586055a41313eaee3efa2d7a34522fde5626",
-                "reference": "474b586055a41313eaee3efa2d7a34522fde5626",
+                "url": "https://api.github.com/repos/MammatusPHP/app/zipball/e014bf55d88d88c6a02008431f5130cb75fdef34",
+                "reference": "e014bf55d88d88c6a02008431f5130cb75fdef34",
                 "shasum": ""
             },
             "require": {
@@ -1359,7 +1359,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-11T20:27:04+00:00"
+            "time": "2025-03-19T12:41:07+00:00"
         },
         {
             "name": "mammatus/kubernetes-attributes",
@@ -1564,12 +1564,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/MammatusPHP/queue-attributes.git",
-                "reference": "fe031df9489d5707b133f85bbb143ae63036a0ae"
+                "reference": "cdf080edd555fdcf6110bde3b5974d903f63bba9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MammatusPHP/queue-attributes/zipball/fe031df9489d5707b133f85bbb143ae63036a0ae",
-                "reference": "fe031df9489d5707b133f85bbb143ae63036a0ae",
+                "url": "https://api.github.com/repos/MammatusPHP/queue-attributes/zipball/cdf080edd555fdcf6110bde3b5974d903f63bba9",
+                "reference": "cdf080edd555fdcf6110bde3b5974d903f63bba9",
                 "shasum": ""
             },
             "require": {
@@ -1601,7 +1601,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-03T15:15:45+00:00"
+            "time": "2025-03-24T08:20:34+00:00"
         },
         {
             "name": "mammatus/queue-contracts",
@@ -1609,12 +1609,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/MammatusPHP/queue-contracts.git",
-                "reference": "58cfe7abd28052afcc13b14ea104162e46d8edd2"
+                "reference": "6a976b65614eee41500284ef61df14dc7e8e5444"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MammatusPHP/queue-contracts/zipball/58cfe7abd28052afcc13b14ea104162e46d8edd2",
-                "reference": "58cfe7abd28052afcc13b14ea104162e46d8edd2",
+                "url": "https://api.github.com/repos/MammatusPHP/queue-contracts/zipball/6a976b65614eee41500284ef61df14dc7e8e5444",
+                "reference": "6a976b65614eee41500284ef61df14dc7e8e5444",
                 "shasum": ""
             },
             "require": {
@@ -1646,7 +1646,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-03T23:13:36+00:00"
+            "time": "2025-03-19T14:16:49+00:00"
         },
         {
             "name": "mindplay/composer-locator",
@@ -1696,16 +1696,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4"
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
-                "reference": "aef6ee73a77a66e404dd6540934a9ef1b3c855b4",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.8.1"
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
             },
             "funding": [
                 {
@@ -1795,7 +1795,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T17:15:07+00:00"
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2880,6 +2880,7 @@
                 "issues": "https://github.com/Roave/Signature/issues",
                 "source": "https://github.com/Roave/Signature/tree/1.9.0"
             },
+            "abandoned": true,
             "time": "2025-02-05T15:43:11+00:00"
         },
         {
@@ -5710,12 +5711,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/jakubkulhan/bunny.git",
-                "reference": "3f43b5126455a870fa653d79c26f59e36d0595e1"
+                "reference": "46e3ab980b09b956f7b120f82065adc34651e530"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jakubkulhan/bunny/zipball/3f43b5126455a870fa653d79c26f59e36d0595e1",
-                "reference": "3f43b5126455a870fa653d79c26f59e36d0595e1",
+                "url": "https://api.github.com/repos/jakubkulhan/bunny/zipball/46e3ab980b09b956f7b120f82065adc34651e530",
+                "reference": "46e3ab980b09b956f7b120f82065adc34651e530",
                 "shasum": ""
             },
             "require": {
@@ -5776,7 +5777,7 @@
                 "issues": "https://github.com/jakubkulhan/bunny/issues",
                 "source": "https://github.com/jakubkulhan/bunny/tree/0.6.x"
             },
-            "time": "2025-03-10T13:33:49+00:00"
+            "time": "2025-03-23T17:22:20+00:00"
         },
         {
             "name": "colinodell/json5",
@@ -5917,23 +5918,23 @@
         },
         {
             "name": "composer-unused/symbol-parser",
-            "version": "0.2.5",
+            "version": "0.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer-unused/symbol-parser.git",
-                "reference": "96cee7244aea405e936247d42c49332d52d90ae7"
+                "reference": "7576ca41ca6ebd46b3c4f18d6adb6f1b340bb694"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer-unused/symbol-parser/zipball/96cee7244aea405e936247d42c49332d52d90ae7",
-                "reference": "96cee7244aea405e936247d42c49332d52d90ae7",
+                "url": "https://api.github.com/repos/composer-unused/symbol-parser/zipball/7576ca41ca6ebd46b3c4f18d6adb6f1b340bb694",
+                "reference": "7576ca41ca6ebd46b3c4f18d6adb6f1b340bb694",
                 "shasum": ""
             },
             "require": {
                 "composer-unused/contracts": "^0.3",
                 "nikic/php-parser": "^4.18 || ^5.0",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.25",
+                "phpstan/phpdoc-parser": "^1.25 || ^2",
                 "psr/container": "^1.0 || ^2.0",
                 "psr/log": "^1.1 || ^2 || ^3",
                 "symfony/finder": "^5.3 || ^6.0 || ^7.0"
@@ -5984,7 +5985,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-03-09T15:25:51+00:00"
+            "time": "2025-03-17T14:27:54+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -7013,16 +7014,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.17.0",
+            "version": "2.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "075bc0c26631110584175de6523ab3f1652eb28e"
+                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/075bc0c26631110584175de6523ab3f1652eb28e",
-                "reference": "075bc0c26631110584175de6523ab3f1652eb28e",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
+                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
                 "shasum": ""
             },
             "require": {
@@ -7072,7 +7073,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.17.0"
+                "source": "https://github.com/filp/whoops/tree/2.18.0"
             },
             "funding": [
                 {
@@ -7080,7 +7081,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-25T12:00:00+00:00"
+            "time": "2025-03-15T12:00:00+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -8821,40 +8822,40 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v7.11.0",
+            "version": "v7.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "994ea93df5d4132f69d3f1bd74730509df6e8a05"
+                "reference": "995245421d3d7593a6960822063bdba4f5d7cf1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/994ea93df5d4132f69d3f1bd74730509df6e8a05",
-                "reference": "994ea93df5d4132f69d3f1bd74730509df6e8a05",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/995245421d3d7593a6960822063bdba4f5d7cf1a",
+                "reference": "995245421d3d7593a6960822063bdba4f5d7cf1a",
                 "shasum": ""
             },
             "require": {
-                "filp/whoops": "^2.16.0",
-                "nunomaduro/termwind": "^1.15.1",
+                "filp/whoops": "^2.17.0",
+                "nunomaduro/termwind": "^1.17.0",
                 "php": "^8.1.0",
-                "symfony/console": "^6.4.12"
+                "symfony/console": "^6.4.17"
             },
             "conflict": {
                 "laravel/framework": ">=11.0.0"
             },
             "require-dev": {
-                "brianium/paratest": "^7.3.1",
-                "laravel/framework": "^10.48.22",
-                "laravel/pint": "^1.18.1",
-                "laravel/sail": "^1.36.0",
+                "brianium/paratest": "^7.4.8",
+                "laravel/framework": "^10.48.29",
+                "laravel/pint": "^1.21.2",
+                "laravel/sail": "^1.41.0",
                 "laravel/sanctum": "^3.3.3",
-                "laravel/tinker": "^2.10.0",
-                "nunomaduro/larastan": "^2.9.8",
-                "orchestra/testbench-core": "^8.28.3",
-                "pestphp/pest": "^2.35.1",
+                "laravel/tinker": "^2.10.1",
+                "nunomaduro/larastan": "^2.10.0",
+                "orchestra/testbench-core": "^8.35.0",
+                "pestphp/pest": "^2.36.0",
                 "phpunit/phpunit": "^10.5.36",
                 "sebastian/environment": "^6.1.0",
-                "spatie/laravel-ignition": "^2.8.0"
+                "spatie/laravel-ignition": "^2.9.1"
             },
             "type": "library",
             "extra": {
@@ -8913,7 +8914,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-10-15T15:12:40+00:00"
+            "time": "2025-03-14T22:35:49+00:00"
         },
         {
             "name": "nunomaduro/termwind",
@@ -9836,16 +9837,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.21",
+            "version": "1.12.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "14276fdef70575106a3392a4ed553c06a984df28"
+                "reference": "29201e7a743a6ab36f91394eab51889a82631428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/14276fdef70575106a3392a4ed553c06a984df28",
-                "reference": "14276fdef70575106a3392a4ed553c06a984df28",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/29201e7a743a6ab36f91394eab51889a82631428",
+                "reference": "29201e7a743a6ab36f91394eab51889a82631428",
                 "shasum": ""
             },
             "require": {
@@ -9890,7 +9891,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-09T09:24:50+00:00"
+            "time": "2025-03-23T14:57:32+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -10514,16 +10515,16 @@
         },
         {
             "name": "psalm/plugin-mockery",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-mockery.git",
-                "reference": "4967cf80e32ba78d1e5a8f7f5363dfa62b16dfff"
+                "reference": "684e5b53f80b0879e92335301f612b006f0f73f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-mockery/zipball/4967cf80e32ba78d1e5a8f7f5363dfa62b16dfff",
-                "reference": "4967cf80e32ba78d1e5a8f7f5363dfa62b16dfff",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-mockery/zipball/684e5b53f80b0879e92335301f612b006f0f73f4",
+                "reference": "684e5b53f80b0879e92335301f612b006f0f73f4",
                 "shasum": ""
             },
             "require": {
@@ -10531,7 +10532,7 @@
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "mockery/mockery": "^1.0",
                 "php": ">=8.1",
-                "vimeo/psalm": "dev-master || ^5.0 || ^6"
+                "vimeo/psalm": "dev-master || ^5.0 || ^6 || ^7"
             },
             "require-dev": {
                 "codeception/codeception": "^4.1.9",
@@ -10565,9 +10566,9 @@
             "description": "Psalm plugin for Mockery",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-mockery/issues",
-                "source": "https://github.com/psalm/psalm-plugin-mockery/tree/1.2.0"
+                "source": "https://github.com/psalm/psalm-plugin-mockery/tree/1.2.1"
             },
-            "time": "2025-01-26T11:02:29+00:00"
+            "time": "2025-03-20T10:51:18+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -10835,16 +10836,16 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109"
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109",
-                "reference": "3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
                 "shasum": ""
             },
             "require": {
@@ -10905,9 +10906,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/2.1.0"
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
             },
-            "time": "2025-03-02T04:48:29+00:00"
+            "time": "2025-03-22T05:38:12+00:00"
         },
         {
             "name": "ramsey/uuid",
@@ -12677,16 +12678,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.3",
+            "version": "3.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
                 "shasum": ""
             },
             "require": {
@@ -12753,11 +12754,11 @@
                     "type": "open_collective"
                 },
                 {
-                    "url": "https://thanks.dev/phpcsstandards",
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-23T17:04:15+00:00"
+            "time": "2025-03-18T05:04:51+00:00"
         },
         {
             "name": "symfony/config",

--- a/etc/generated_templates/AbstractList.php.twig
+++ b/etc/generated_templates/AbstractList.php.twig
@@ -16,9 +16,11 @@ abstract class AbstractList
      */
     final protected function workers(): iterable
     {
-{% for worker in workers %}
+{% for hash, worker in workers %}
         /** @see \{{ worker.class }} */
-        yield '{% if action.splitOut == true %}kubernetes{% else %}internal{% endif %}-{{ worker.class|replace({'\\': '-'}) }}' => new Worker(
+        yield '{% if action.splitOut == true %}kubernetes{% else %}internal{% endif %}-{{ worker.class|replace({'\\': '-'}) }}-{{ worker.consumer.friendlyName|length > 0 ? worker.consumer.friendlyName : hash }}' => new Worker(
+            '{{ hash }}',
+            '{{ worker.consumer.friendlyName }}',
 {% if worker.splitOut == true %}
             'kubernetes',
 {% else %}

--- a/etc/generated_templates/WorkQueueMap.php.twig
+++ b/etc/generated_templates/WorkQueueMap.php.twig
@@ -12,8 +12,8 @@ use Mammatus\Queue\Contracts\Work;
 abstract class WorkQueueMap
 {
     private const MAP = [
-{% for worker in workers %}
-        \{{ worker.dtoClass }}::class => '{{ worker.consumer.queue }}',
+{% for item in items %}
+        \{{ item.dtoClass }}::class => '{{ item.queue }}',
 {% endfor %}
     ];
 

--- a/src/App.php
+++ b/src/App.php
@@ -44,7 +44,7 @@ final class App extends AbstractList implements Bootable, Listener
     {
         try {
             foreach ($this->workers() as $worker) {
-                if ($worker->class !== $argv->className) {
+                if ($worker->hash !== $argv->hash) {
                     continue;
                 }
 

--- a/src/App/Queue.php
+++ b/src/App/Queue.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Mammatus\Queue\App;
 
 use Mammatus\Contracts\Argv;
-use Mammatus\Queue\Contracts\Worker;
 
 final class Queue implements Argv
 {
-    /** @param class-string<Worker> $className */
     public function __construct(
-        public string $className,
+        public string $hash,
     ) {
     }
 }

--- a/src/BuildIn/Noop.php
+++ b/src/BuildIn/Noop.php
@@ -10,7 +10,9 @@ use Mammatus\Queue\Contracts\Worker;
 use function React\Async\await;
 use function WyriHaximus\React\timedPromise;
 
-#[Consumer(queue: 'noop', dtoClass: EmptyMessage::class, concurrency: 1)]
+#[Consumer(friendlyName: '', queue: 'noop', dtoClass: EmptyMessage::class, concurrency: 1)]
+#[Consumer(friendlyName: 'noop_2', queue: 'noop', dtoClass: EmptyMessage::class, concurrency: 2)]
+#[Consumer(friendlyName: 'noop_3', queue: 'noop', dtoClass: EmptyMessage::class, concurrency: 3)]
 final class Noop implements Worker
 {
     public function perform(EmptyMessage $work): void

--- a/src/Composer/Collector.php
+++ b/src/Composer/Collector.php
@@ -26,8 +26,8 @@ final class Collector implements ItemCollector
     {
         $attributes = [];
         foreach ((new \ReflectionClass($class->getName()))->getAttributes() as $attributeReflection) {
-            $attribute                     = $attributeReflection->newInstance();
-            $attributes[$attribute::class] = $attribute;
+            $attribute                       = $attributeReflection->newInstance();
+            $attributes[$attribute::class][] = $attribute;
         }
 
         if (! array_key_exists(Consumer::class, $attributes)) {
@@ -69,14 +69,16 @@ final class Collector implements ItemCollector
                     continue;
                 }
 
-                /** @psalm-suppress ArgumentTypeCoercion */
-                yield new Item(
-                    $class->getName(),
-                    $method->getName(),
-                    $messageDTO,
-                    $attributes[Consumer::class], /** @phpstan-ignore-line */
-                    array_key_exists(SplitOut::class, $attributes),
-                );
+                foreach ($attributes[Consumer::class] as $attribute) {
+                    /** @psalm-suppress ArgumentTypeCoercion */
+                    yield new Item(
+                        $class->getName(),
+                        $method->getName(),
+                        $messageDTO,
+                        $attribute, /** @phpstan-ignore-line */
+                        array_key_exists(SplitOut::class, $attributes),
+                    );
+                }
             }
         }
     }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -59,7 +59,7 @@ final class Consumer implements Listener
         ];
         $this->logger->debug('Starting ' . $worker->concurrency . ' workers for ' . $worker->class);
         for ($i = 0; $i < $worker->concurrency; $i++) {
-            $this->logger->info('Starting consumer ' . $i . ' of ' . $worker->concurrency . ' for ' . $worker->class);
+            $this->logger->info('Starting consumer ' . ($i + 1) . ' of ' . $worker->concurrency . ' for ' . $worker->class);
             $promises[] = async(fn () => $this->consume($worker, $workerInstance, new ContextLogger($logger, ['fiber' => $i])))();
         }
 

--- a/src/Generated/AbstractList.php
+++ b/src/Generated/AbstractList.php
@@ -19,10 +19,38 @@ abstract class AbstractList
     final protected function workers(): iterable
     {
         /** @see \Mammatus\Queue\BuildIn\Noop */
-        yield 'internal-Mammatus-Queue-BuildIn-Noop' => new Worker(
+        yield 'internal-Mammatus-Queue-BuildIn-Noop-ae45abb14e21aa2ae051315fb47a7b12' => new Worker(
+            'ae45abb14e21aa2ae051315fb47a7b12',
+            '',
             'internal',
             'noop',
             1,
+            Noop::class,
+            'perform',
+            EmptyMessage::class,
+            json_decode('[]', true), /** @phpstan-ignore-line */
+        );
+
+        /** @see \Mammatus\Queue\BuildIn\Noop */
+        yield 'internal-Mammatus-Queue-BuildIn-Noop-noop_2' => new Worker(
+            '03d9cb358a96e3cd6c0ec1759d39290b',
+            'noop_2',
+            'internal',
+            'noop',
+            2,
+            Noop::class,
+            'perform',
+            EmptyMessage::class,
+            json_decode('[]', true), /** @phpstan-ignore-line */
+        );
+
+        /** @see \Mammatus\Queue\BuildIn\Noop */
+        yield 'internal-Mammatus-Queue-BuildIn-Noop-noop_3' => new Worker(
+            '8103cfd64b01225ca080d52daff46dea',
+            'noop_3',
+            'internal',
+            'noop',
+            3,
             Noop::class,
             'perform',
             EmptyMessage::class,

--- a/src/Kubernetes/Helm/QueueConsumersValues.php
+++ b/src/Kubernetes/Helm/QueueConsumersValues.php
@@ -12,6 +12,7 @@ use WyriHaximus\Broadcast\Contracts\Listener;
 use function array_filter;
 use function array_map;
 use function str_replace;
+use function strlen;
 
 final class QueueConsumersValues extends AbstractList implements Listener
 {
@@ -27,9 +28,9 @@ final class QueueConsumersValues extends AbstractList implements Listener
             'deployments',
             array_map(
                 static fn (Worker $worker): array => [
-                    'name' => 'queue-worker-' . str_replace('.', '-', $worker->queue),
+                    'name' => 'queue-worker-' . str_replace('.', '-', $worker->queue) . '-' . (strlen($worker->friendlyName) > 0 ? $worker->friendlyName : $worker->hash),
                     'command' => 'mammatus-queue',
-                    'arguments' => [$worker->class],
+                    'arguments' => [$worker->hash],
                     'addOns' => $worker->addOns,
                 ],
                 $this->type === false ? [...$this->workers()] : array_filter(

--- a/src/Worker.php
+++ b/src/Worker.php
@@ -14,6 +14,8 @@ final readonly class Worker
      * @param array<string, mixed>         $addOns
      */
     public function __construct(
+        public string $hash,
+        public string $friendlyName,
         public string $type,
         public string $queue,
         public int $concurrency,

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -30,9 +30,9 @@ final class AppTest extends AsyncTestCase
         $container->expects('get')->with(Noop::class)->once()->andReturn(new Noop());
 
         $logger->expects('debug')->withArgs(static fn (string $error): bool => str_contains($error, ' for ' . Noop::class))->atLeast()->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->atLeast()->once();
 
-        $exitCode = (new App($consumer, $logger))->boot(new App\Queue(Noop::class));
+        $exitCode = (new App($consumer, $logger))->boot(new App\Queue('ae45abb14e21aa2ae051315fb47a7b12'));
 
         self::assertSame(ExitCode::Success, $exitCode);
     }
@@ -49,9 +49,9 @@ final class AppTest extends AsyncTestCase
         $container->expects('get')->with(Noop::class)->once()->andReturn(new Angry($exception));
 
         $logger->expects('debug')->withArgs(static fn (string $error): bool => str_contains($error, ' for ' . Noop::class))->atLeast()->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->atLeast()->once();
 
-        $exitCode = (new App($consumer, $logger))->boot(new App\Queue(Noop::class));
+        $exitCode = (new App($consumer, $logger))->boot(new App\Queue('ae45abb14e21aa2ae051315fb47a7b12'));
 
         self::assertSame(ExitCode::Success, $exitCode);
     }
@@ -71,9 +71,9 @@ final class AppTest extends AsyncTestCase
 
             return array_key_exists('exception', $context) && $context['exception']->getMessage() === 'Worker instance must be instance of ' . WorkerContract::class;
         })->atLeast()->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Sad::class)->never();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Sad::class)->never();
 
-        $exitCode = (new App($consumer, $logger))->boot(new App\Queue(Noop::class));
+        $exitCode = (new App($consumer, $logger))->boot(new App\Queue('ae45abb14e21aa2ae051315fb47a7b12'));
 
         self::assertSame(ExitCode::Failure, $exitCode);
     }

--- a/tests/Composer/ItemTest.php
+++ b/tests/Composer/ItemTest.php
@@ -24,6 +24,7 @@ final class ItemTest extends TestCase
             EmptyMessage::class,
             new Consumer(
                 'test',
+                'test',
                 EmptyMessage::class,
                 1337,
                 new Resources(
@@ -34,7 +35,7 @@ final class ItemTest extends TestCase
             false,
         );
         self::assertSame(
-            '{"class":"Mammatus\\\\Queue\\\\BuildIn\\\\Noop","method":"perform","dtoClass":"Mammatus\\\\Queue\\\\BuildIn\\\\EmptyMessage","consumer":{"addOns":[{"type":"container","helper":"mammatus.container.resources","arguments":{"cpu":"666m","memory":"3072Mi"}}],"queue":"test","dtoClass":"Mammatus\\\\Queue\\\\BuildIn\\\\EmptyMessage","concurrency":1337},"split_out":false}',
+            '{"class":"Mammatus\\\\Queue\\\\BuildIn\\\\Noop","method":"perform","dtoClass":"Mammatus\\\\Queue\\\\BuildIn\\\\EmptyMessage","consumer":{"addOns":[{"type":"container","helper":"mammatus.container.resources","arguments":{"cpu":"666m","memory":"3072Mi"}}],"friendlyName":"test","queue":"test","dtoClass":"Mammatus\\\\Queue\\\\BuildIn\\\\EmptyMessage","concurrency":1337},"split_out":false}',
             json_encode($item),
         );
     }

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -26,7 +26,7 @@ final class ConsumerTest extends AsyncTestCase
         $logger->expects('debug')->with('Setting up logger for ' . Noop::class)->once();
         $logger->expects('debug')->with('Getting worker instance for ' . Noop::class)->once();
         $logger->expects('debug')->with('Starting 1 workers for ' . Noop::class)->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->atLeast()->once();
         $logger->expects('debug')->with('Hydrating message')->once();
         $logger->expects('debug')->with('Invoking worker')->once();
         $logger->expects('debug')->with('Acknowledging message')->once();
@@ -35,6 +35,8 @@ final class ConsumerTest extends AsyncTestCase
         $message->setBody('[]');
 
         $worker = new Worker(
+            '1829be63f4279d034d6b46caa90b1f8d',
+            'noop_1',
             'internal',
             'noop',
             1,
@@ -58,7 +60,7 @@ final class ConsumerTest extends AsyncTestCase
         $logger->expects('debug')->with('Setting up logger for ' . Noop::class)->once();
         $logger->expects('debug')->with('Getting worker instance for ' . Noop::class)->once();
         $logger->expects('debug')->with('Starting 1 workers for ' . Noop::class)->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->once();
         $logger->expects('debug')->with('Hydrating message')->atLeast()->once();
         $logger->expects('debug')->with('Invoking worker')->never();
         $logger->expects('debug')->with('Rejecting message')->atLeast()->once();
@@ -74,6 +76,8 @@ final class ConsumerTest extends AsyncTestCase
         $message->setBody('{]');
 
         $worker = new Worker(
+            '1829be63f4279d034d6b46caa90b1f8d',
+            'noop_1',
             'internal',
             'noop',
             1,

--- a/tests/Kubernetes/Helm/QueueConsumersValuesTest.php
+++ b/tests/Kubernetes/Helm/QueueConsumersValuesTest.php
@@ -8,7 +8,7 @@ use Mammatus\Kubernetes\Events\Helm\Values;
 use Mammatus\Queue\Kubernetes\Helm\QueueConsumersValues;
 use WyriHaximus\TestUtilities\TestCase;
 
-final class CronJobsValuesTest extends TestCase
+final class QueueConsumersValuesTest extends TestCase
 {
     /** @test */
     public function none(): void
@@ -29,10 +29,22 @@ final class CronJobsValuesTest extends TestCase
 
         self::assertSame([
             'deployments' => [
-                'internal-Mammatus-Queue-BuildIn-Noop' => [
-                    'name' => 'queue-worker-noop',
+                'internal-Mammatus-Queue-BuildIn-Noop-ae45abb14e21aa2ae051315fb47a7b12' => [
+                    'name' => 'queue-worker-noop-ae45abb14e21aa2ae051315fb47a7b12',
                     'command' => 'mammatus-queue',
-                    'arguments' => ['Mammatus\Queue\BuildIn\Noop'],
+                    'arguments' => ['ae45abb14e21aa2ae051315fb47a7b12'],
+                    'addOns' => [],
+                ],
+                'internal-Mammatus-Queue-BuildIn-Noop-noop_2' => [
+                    'name' => 'queue-worker-noop-noop_2',
+                    'command' => 'mammatus-queue',
+                    'arguments' => ['03d9cb358a96e3cd6c0ec1759d39290b'],
+                    'addOns' => [],
+                ],
+                'internal-Mammatus-Queue-BuildIn-Noop-noop_3' => [
+                    'name' => 'queue-worker-noop-noop_3',
+                    'command' => 'mammatus-queue',
+                    'arguments' => ['8103cfd64b01225ca080d52daff46dea'],
                     'addOns' => [],
                 ],
             ],

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -38,7 +38,12 @@ final class ManagerTest extends AsyncTestCase
         $logger->expects('debug')->withArgs(static fn (string $error): bool => str_contains($error, ' for ' . Noop::class))->atLeast()->once();
         $logger->expects('debug')->with('Starting queue manager')->once();
         $logger->expects('debug')->with('Started queue manager')->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 2 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 2 of 2 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 3 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 2 of 3 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 3 of 3 for ' . Noop::class)->atLeast()->once();
         $logger->expects('debug')->with('Stopping queue manager')->once();
         $logger->expects('debug')->with('Stopped queue manager')->once();
 
@@ -65,7 +70,12 @@ final class ManagerTest extends AsyncTestCase
         $logger->expects('debug')->withArgs(static fn (string $error): bool => str_contains($error, ' for ' . Noop::class))->atLeast()->once();
         $logger->expects('debug')->with('Starting queue manager')->once();
         $logger->expects('debug')->with('Started queue manager')->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 2 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 2 of 2 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 1 of 3 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 2 of 3 for ' . Noop::class)->atLeast()->once();
+        $logger->expects('info')->with('Starting consumer 3 of 3 for ' . Noop::class)->atLeast()->once();
         $logger->expects('debug')->with('Stopping queue manager')->once();
         $logger->expects('debug')->with('Stopped queue manager')->once();
 
@@ -102,7 +112,7 @@ final class ManagerTest extends AsyncTestCase
             return array_key_exists('exception', $context) && $context['exception']->getMessage() === 'Worker instance must be instance of ' . WorkerContract::class;
         })->atLeast()->once();
         $logger->expects('debug')->with('Started queue manager')->once();
-        $logger->expects('info')->with('Starting consumer 0 of 1 for ' . Noop::class)->never();
+        $logger->expects('info')->with('Starting consumer 1 of 1 for ' . Noop::class)->never();
         $logger->expects('debug')->with('Stopping queue manager')->never();
         $logger->expects('debug')->with('Stopped queue manager')->never();
 


### PR DESCRIPTION
This changes from a class name based argument for the bin to a hash based one. This is because while for now everything happens outside of code, in the future the code running should be able to pass argument to the consumer to only select specific messages. For example when it needs more memory for bigger tasks. So have a couple of big consumers that do everything, and only have the small consumers pick up the small tasks