### PR TITLE
Use `Remove::*OnlyIfItExists`

### DIFF
--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -56,10 +56,10 @@ final class Plugin implements GenerativePlugin
 
     public function compile(string $rootPath, ItemContract ...$items): void
     {
-        Remove::directoryContents($rootPath . '/src/Consumer');
-        Remove::directoryContents($rootPath . '/src/Kubernetes');
-        Remove::file($rootPath . '/src/Hydrator.php');
-        Remove::file($rootPath . '/src/Producer.php');
+        Remove::directoryContentsOnlyIfItExists($rootPath . '/src/Consumer');
+        Remove::directoryContentsOnlyIfItExists($rootPath . '/src/Kubernetes');
+        Remove::fileOnlyIfItExists($rootPath . '/src/Hydrator.php');
+        Remove::fileOnlyIfItExists($rootPath . '/src/Producer.php');
 
         $map     = [];
         $workers = [];


### PR DESCRIPTION
This ensures we don't get errors when deleting things before we regenerate them